### PR TITLE
Use correct C declaration for enum types

### DIFF
--- a/ui_gl.c
+++ b/ui_gl.c
@@ -652,7 +652,7 @@ static void robwidget_layout(GLrobtkLV2UI * const self, bool setsize, bool init)
 		self->width = nox;
 		self->height = noy;
 	} else if (nox > self->width || noy > self->height) {
-		LVGLResize rsz = plugin_scale_mode(self->ui);
+		enum LVGLResize rsz = plugin_scale_mode(self->ui);
 		if (rsz == LVGL_ZOOM_TO_ASPECT || rsz == LVGL_LAYOUT_TO_FIT) {
 			puglUpdateGeometryConstraints(self->view, nox, noy, rsz == LVGL_ZOOM_TO_ASPECT);
 			return;
@@ -662,7 +662,7 @@ static void robwidget_layout(GLrobtkLV2UI * const self, bool setsize, bool init)
 		if (nox > self->width) self->width = nox;
 		if (noy > self->height) self->height = noy;
 	} else if (nox < self->width || noy < self->height) {
-		LVGLResize rsz = plugin_scale_mode(self->ui);
+		enum LVGLResize rsz = plugin_scale_mode(self->ui);
 		if (rsz == LVGL_ZOOM_TO_ASPECT || rsz == LVGL_LAYOUT_TO_FIT) {
 			puglUpdateGeometryConstraints(self->view, nox, noy, rsz == LVGL_ZOOM_TO_ASPECT);
 		}


### PR DESCRIPTION
Without a typedef an enum variable must be declared with the enum keyword in C. This change adds this and allows ui_gl.c to be compiled with just a C compiler (as should be with that .c extension).